### PR TITLE
Update --submission_type optional with auto-detection based on file extensions and remove unnecessary check

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For the image scope, the program takes up to two files, depending on the prompt 
 ## Argument Details
 | Argument          | Description                                      | Required |
 |------------------|--------------------------------------------------|----------|
-| `--submission_type` | Type of submission (from `arg_options.FileType`) | ✅ |
+| `--submission_type` | Type of submission (from `arg_options.FileType`) | ❌ |
 | `--prompt`       | The name of a preddefined prompt file (from `arg_options.Prompt`) | ❌ **|
 | `--prompt_text`       | Additional string text prompt that can be fed to model. | ❌ ** |
 | `--prompt_custom`       | The name of prompt file uploaded to be used by model. | ❌ ** |
@@ -51,6 +51,13 @@ If the "text" scope is selected, the program will identify student errors in the
 If the "image" scope is selected, the program will identify issues in submission images, optionally comparing them to reference solutions. Question numbers can be specified by adding the tag `markus_question_name: <question name>` to the metadata for the code cell that generates the submission image. The previous cell's markdown content will be used as the question's context.
 
 ## Submission Type
+The program automatically detects submission type based on file extensions in the assignment directory:
+- Files ending with `_submission.ipynb` → jupyter notebook
+- Files ending with `_submission.py` → python file  
+- Files ending with `_submission.pdf` → PDF document
+
+The user can also explicitly specify the submission type using the `--submission_type` argument if auto-detection is not suitable.
+
 Currently, jupyter notebook, pdf, and python assignments are supported.
 
 ## Prompts
@@ -242,28 +249,28 @@ python -m ai_feedback -h
 
 #### Evaluate cnn_example test using openAI model 
 ```bash
-python -m ai_feedback --submission_type python --prompt code_lines --scope code --assignment test_submissions/cnn_example --model  openai  --output stdout
+python -m ai_feedback --prompt code_lines --scope code --assignment test_submissions/cnn_example --model openai --output stdout
 ```
 
 #### Evaluate cnn_example test using openAI model and custom prompt 
 ```bash
-python -m ai_feedback --submission_type python --prompt_text "Evaluate the student's code readability." --scope code --assignment test_submissions/cnn_example --model  openai  --output stdout
+python -m ai_feedback --prompt_text "Evaluate the student's code readability." --scope code --assignment test_submissions/cnn_example --model openai --output stdout
 ```
 
 #### Evaluate pdf_example test using openAI model 
 ```bash
-python -m ai_feedback --submission_type pdf --prompt text_pdf_analyze --scope text --assignment test_submissions/pdf_example --model openai  --output direct
+python -m ai_feedback --prompt text_pdf_analyze --scope text --assignment test_submissions/pdf_example --model openai --output direct
 ```
 
 #### Evaluate question1 of test1 of ggr274 homework using DeepSeek model 
 ```bash
-python -m ai_feedback  --submission_type jupyter --prompt code_table \
+python -m ai_feedback --prompt code_table \
   --scope code --assignment test_submissions/ggr274_homework5/test1 --question 1 --model deepSeek-R1:70B --output markdown
 ```
 
 #### Evaluate the image for question 5b of ggr274 homework with Llama3.2-vision 
 ```sh
-python3 -m ai_feedback --submission_type jupyter --prompt image_analyze --scope image --assignment ./test_submissions/ggr274_homework5/image_test2 --question "Question 5b" --model llama3.2-vision --output stdout
+python3 -m ai_feedback --prompt image_analyze --scope image --assignment ./test_submissions/ggr274_homework5/image_test2 --question "Question 5b" --model llama3.2-vision --output stdout
 ```
 
 #### Using Ollama

--- a/ai_feedback/__main__.py
+++ b/ai_feedback/__main__.py
@@ -13,8 +13,7 @@ from .helpers.constants import TEST_OUTPUTS_DIRECTORY, HELP_MESSAGES
 
 
 def detect_submission_type(assignment_folder: str) -> str:
-    """
-    Automatically detect the submission type based on file extensions in the assignment folder.
+    """Automatically detect the submission type based on file extensions in the assignment folder.
     
     Args:
         assignment_folder (str): Path to the assignment directory.
@@ -118,9 +117,6 @@ def main() -> int:
 
     # Auto-detect submission type if not provided
     if args.submission_type is None:
-        if not args.assignment:
-            print("Error: --assignment is required when --submission_type is not specified.")
-            sys.exit(1)
         args.submission_type = detect_submission_type(args.assignment)
 
     prompt_content = ""

--- a/ai_feedback/__main__.py
+++ b/ai_feedback/__main__.py
@@ -90,11 +90,11 @@ def main() -> int:
         "--scope",
         type=str,
         choices=arg_options.get_enum_values(arg_options.Scope),
-        required=False,
+        required=True,
         help=HELP_MESSAGES["scope"],
     )
     parser.add_argument(
-        "--assignment", type=str, required=False, help=HELP_MESSAGES["assignment"]
+        "--assignment", type=str, required=True, help=HELP_MESSAGES["assignment"]
     )
     parser.add_argument(
         "--question", type=str, required=False, help=HELP_MESSAGES["question"]
@@ -103,14 +103,14 @@ def main() -> int:
         "--model",
         type=str,
         choices=arg_options.get_enum_values(arg_options.Models),
-        required=False,
+        required=True,
         help=HELP_MESSAGES["model"],
     )
     parser.add_argument(
         "--output",
         type=str,
         choices=arg_options.get_enum_values(arg_options.OutputType),
-        required=False,
+        required=True,
         help=HELP_MESSAGES["output"],
     )
 

--- a/presentation_materials/Example_commands.md
+++ b/presentation_materials/Example_commands.md
@@ -9,7 +9,7 @@ python -m ai_feedback \
 --submission_type jupyter \
 --prompt code_explanation \
 --scope code \
---assignment presentation_materials/iris_image_examples/image_test_incorrect \
+--assignment test_submissions/iris_demo_example/image_test_incorrect \
 --question "4" \
 --model claude-3.7-sonnet \
 --output stdout
@@ -50,7 +50,7 @@ python -m ai_feedback \
 --submission_type jupyter \
 --prompt image_analyze \
 --scope image \
---assignment presentation_materials/iris_image_examples/image_test_incorrect \
+--assignment test_submissions/iris_demo_example/image_test_incorrect \
 --question "4" \
 --model openai \
 --output stdout

--- a/presentation_materials/Example_commands.md
+++ b/presentation_materials/Example_commands.md
@@ -9,7 +9,7 @@ python -m ai_feedback \
 --submission_type jupyter \
 --prompt code_explanation \
 --scope code \
---assignment test_submissions/iris_demo_example/image_test_incorrect \
+--assignment presentation_materials/iris_image_examples/image_test_incorrect \
 --question "4" \
 --model claude-3.7-sonnet \
 --output stdout
@@ -50,7 +50,7 @@ python -m ai_feedback \
 --submission_type jupyter \
 --prompt image_analyze \
 --scope image \
---assignment test_submissions/iris_demo_example/image_test_incorrect \
+--assignment presentation_materials/iris_image_examples/image_test_incorrect \
 --question "4" \
 --model openai \
 --output stdout


### PR DESCRIPTION
- Made `--submission_type` optional;
- Added `detect_submission_type()` function for automatic detection
- Auto-detection based on file patterns:
    *_submission.ipynb → jupyter
    *_submission.py → python
    *_submission.pdf → pdf

- Remove unnecessary assignment check