### PR TITLE
 Wrap file contents in XML tags

### DIFF
--- a/ai_feedback/helpers/template_utils.py
+++ b/ai_feedback/helpers/template_utils.py
@@ -86,12 +86,12 @@ def gather_file_references(submission: Optional[Path], solution: Optional[Path],
 
 
 def gather_xml_file_contents(
-    submission: Path, solution: Optional[Path] = None, test_output: Optional[Path] = None
+    submission: Optional[Path], solution: Optional[Path] = None, test_output: Optional[Path] = None
 ) -> str:
     """Generate file contents with XML tags for prompt templates.
 
     Args:
-        submission (Path): Student's submission file path
+        submission (Path, optional): Student's submission file path
         solution (Path, optional): Instructor's solution file path
         test_output (Path, optional): Student's test output file path
 
@@ -100,7 +100,8 @@ def gather_xml_file_contents(
     """
     file_contents = ""
 
-    file_contents += _format_file_with_xml_tag(submission, "submission")
+    if submission:
+        file_contents += _format_file_with_xml_tag(submission, "submission")
 
     if solution:
         file_contents += _format_file_with_xml_tag(solution, "solution")

--- a/ai_feedback/helpers/template_utils.py
+++ b/ai_feedback/helpers/template_utils.py
@@ -133,27 +133,25 @@ def _format_file_with_xml_tag(file_path: Path, tag_name: str) -> str:
         # Handle PDF files separately
         if filename.lower().endswith('.pdf'):
             text_content = extract_pdf_text(file_path)
-            lines = text_content.split('\n')
-            return _wrap_lines_with_xml(lines, tag_name, filename, is_pdf=True)
+            return f"<{tag_name} filename=\"{filename}\">\n{text_content}\n</{tag_name}>\n\n"
         else:
             # Handle regular text files
             with open(file_path, "r", encoding="utf-8") as file:
                 lines = file.readlines()
-            return _wrap_lines_with_xml(lines, tag_name, filename, is_pdf=False)
+            return _wrap_lines_with_xml(lines, tag_name, filename)
 
     except Exception as e:
         print(f"Error reading file {filename}: {e}")
         return ""
 
 
-def _wrap_lines_with_xml(lines: List[str], tag_name: str, filename: str, is_pdf: bool = False) -> str:
+def _wrap_lines_with_xml(lines: List[str], tag_name: str, filename: str) -> str:
     """Wrap lines with XML tags and add line numbers.
 
     Args:
         lines (List[str]): List of lines to format
         tag_name (str): The XML tag name (submission, solution, test_output)
         filename (str): The filename to include in the XML tag
-        is_pdf (bool): Whether this is PDF content (affects empty line handling)
 
     Returns:
         str: Formatted content with XML tags and line numbers
@@ -161,18 +159,11 @@ def _wrap_lines_with_xml(lines: List[str], tag_name: str, filename: str, is_pdf:
     content = f"<{tag_name} filename=\"{filename}\">\n"
 
     for i, line in enumerate(lines, start=1):
-        if is_pdf:
-            stripped_line = line.rstrip()
-            if stripped_line.strip():
-                content += f"(Line {i}) {stripped_line}\n"
-            else:
-                content += f"(Line {i}) \n"
+        stripped_line = line.rstrip("\n")
+        if stripped_line.strip():
+            content += f"(Line {i}) {stripped_line}\n"
         else:
-            stripped_line = line.rstrip("\n")
-            if stripped_line.strip():
-                content += f"(Line {i}) {stripped_line}\n"
-            else:
-                content += f"(Line {i}) {line}"
+            content += f"(Line {i}) {line}"
 
     content += f"</{tag_name}>\n\n"
     return content

--- a/ai_feedback/helpers/template_utils.py
+++ b/ai_feedback/helpers/template_utils.py
@@ -156,7 +156,7 @@ def _wrap_lines_with_xml(lines: List[str], tag_name: str, filename: str, is_pdf:
     Returns:
         str: Formatted content with XML tags and line numbers
     """
-    content = f"<{tag_name} file=\"{filename}\">\n"
+    content = f"<{tag_name} filename=\"{filename}\">\n"
 
     for i, line in enumerate(lines, start=1):
         if is_pdf:
@@ -319,7 +319,7 @@ def _get_question_contents(assignment_files: List[Optional[Path]], question_num:
             task_found = True
 
         tag_name = semantic_tags[index] if index < len(semantic_tags) else "file"
-        file_contents += f"<{tag_name} file=\"{file_path.name}\">\n"
+        file_contents += f"<{tag_name} filename=\"{file_path.name}\">\n"
         file_contents += intro_content + "\n\n" if intro_content else ""
         file_contents += task_content + "\n\n"
         file_contents += f"</{tag_name}>\n\n"

--- a/ai_feedback/helpers/template_utils.py
+++ b/ai_feedback/helpers/template_utils.py
@@ -64,7 +64,7 @@ def render_prompt_template(
     return prompt_content.format(**template_data)
 
 
-def gather_file_references(submission: Optional[Path], solution: Optional[Path], test_output: Optional[Path]) -> str:
+def gather_file_references(submission: Optional[Path] = None, solution: Optional[Path] = None, test_output: Optional[Path] = None) -> str:
     """Generate file reference descriptions for prompt templates.
 
     Args:
@@ -86,7 +86,7 @@ def gather_file_references(submission: Optional[Path], solution: Optional[Path],
 
 
 def gather_xml_file_contents(
-    submission: Optional[Path], solution: Optional[Path] = None, test_output: Optional[Path] = None
+    submission: Optional[Path] = None, solution: Optional[Path] = None, test_output: Optional[Path] = None
 ) -> str:
     """Generate file contents with XML tags for prompt templates.
 
@@ -110,38 +110,6 @@ def gather_xml_file_contents(
         file_contents += _format_file_with_xml_tag(test_output, "test_output")
 
     return file_contents
-
-
-def _wrap_lines_with_xml(lines: List[str], tag_name: str, filename: str, is_pdf: bool = False) -> str:
-    """Wrap lines with XML tags and add line numbers.
-    
-    Args:
-        lines (List[str]): List of lines to format
-        tag_name (str): The XML tag name (submission, solution, test_output)
-        filename (str): The filename to include in the XML tag
-        is_pdf (bool): Whether this is PDF content (affects empty line handling)
-    
-    Returns:
-        str: Formatted content with XML tags and line numbers
-    """
-    content = f"<{tag_name} file=\"{filename}\">\n"
-    
-    for i, line in enumerate(lines, start=1):
-        if is_pdf:
-            stripped_line = line.rstrip()
-            if stripped_line.strip():
-                content += f"(Line {i}) {stripped_line}\n"
-            else:
-                content += f"(Line {i}) \n"
-        else:
-            stripped_line = line.rstrip("\n")
-            if stripped_line.strip():
-                content += f"(Line {i}) {stripped_line}\n"
-            else:
-                content += f"(Line {i}) {line}"
-    
-    content += f"</{tag_name}>\n\n"
-    return content
 
 
 def _format_file_with_xml_tag(file_path: Path, tag_name: str) -> str:
@@ -174,6 +142,38 @@ def _format_file_with_xml_tag(file_path: Path, tag_name: str) -> str:
     except Exception as e:
         print(f"Error reading file {filename}: {e}")
         return ""
+
+
+def _wrap_lines_with_xml(lines: List[str], tag_name: str, filename: str, is_pdf: bool = False) -> str:
+    """Wrap lines with XML tags and add line numbers.
+    
+    Args:
+        lines (List[str]): List of lines to format
+        tag_name (str): The XML tag name (submission, solution, test_output)
+        filename (str): The filename to include in the XML tag
+        is_pdf (bool): Whether this is PDF content (affects empty line handling)
+    
+    Returns:
+        str: Formatted content with XML tags and line numbers
+    """
+    content = f"<{tag_name} file=\"{filename}\">\n"
+    
+    for i, line in enumerate(lines, start=1):
+        if is_pdf:
+            stripped_line = line.rstrip()
+            if stripped_line.strip():
+                content += f"(Line {i}) {stripped_line}\n"
+            else:
+                content += f"(Line {i}) \n"
+        else:
+            stripped_line = line.rstrip("\n")
+            if stripped_line.strip():
+                content += f"(Line {i}) {stripped_line}\n"
+            else:
+                content += f"(Line {i}) {line}"
+    
+    content += f"</{tag_name}>\n\n"
+    return content
 
 
 def extract_pdf_text(pdf_path: str) -> str:

--- a/ai_feedback/helpers/template_utils.py
+++ b/ai_feedback/helpers/template_utils.py
@@ -64,11 +64,11 @@ def render_prompt_template(
     return prompt_content.format(**template_data)
 
 
-def gather_file_references(submission: Path, solution: Optional[Path], test_output: Optional[Path]) -> str:
+def gather_file_references(submission: Optional[Path], solution: Optional[Path], test_output: Optional[Path]) -> str:
     """Generate file reference descriptions for prompt templates.
 
     Args:
-        submission (Path): Student's submission file path
+        submission (Path, optional): Student's submission file path
         solution (Path, optional): Instructor's solution file path
         test_output (Path, optional): Student's test output file path
 
@@ -76,7 +76,8 @@ def gather_file_references(submission: Path, solution: Optional[Path], test_outp
         str: Descriptions like "The instructor's solution file..."
     """
     references: List[str] = []
-    references.append(f"The student's submission file is {submission.name}.")
+    if submission:
+        references.append(f"The student's submission file is {submission.name}.")
     if solution:
         references.append(f"The instructor's solution file is {solution.name}.")
     if test_output:

--- a/tests/open_ai_model_tests/integration_test.py
+++ b/tests/open_ai_model_tests/integration_test.py
@@ -4,8 +4,7 @@ from tests.test_helper import mock_and_capture, run_cli_and_capture
 
 
 def test_cnn_example_openai_stdout(capsys, mock_and_capture):
-    """
-    Example 1:
+    """Example 1:
     Evaluate cnn_example test using openAI model and print to stdout.
     python -m ai_feedback --prompt code_lines --scope code \
         --submission test_submissions/cnn_example/cnn_submission \
@@ -30,13 +29,12 @@ def test_cnn_example_openai_stdout(capsys, mock_and_capture):
 
     assert "Compare the student's code and solution code. For each mistake" in output
     assert "(Line 1) import numpy as np" in output
-    assert "=== cnn_submission.py ===" in output
-    assert "=== cnn_solution.py ===" in output
+    assert '<submission file="cnn_submission.py">' in output
+    assert '<solution file="cnn_solution.py">' in output
 
 
 def test_cnn_example_custom_prompt_stdout(capsys, mock_and_capture):
-    """
-    Example 2:
+    """Example 2:
     Evaluate cnn_example test using openAI model and a custom prompt text, printing to stdout.
     python -m ai_feedback --prompt_text "Evaluate the student's code readability." \
         --scope code \
@@ -58,13 +56,12 @@ def test_cnn_example_custom_prompt_stdout(capsys, mock_and_capture):
     ]
     output = run_cli_and_capture(args, capsys)
     assert "Evaluate the student's code readability." in output
-    assert "=== cnn_submission.py ===" in output
+    assert '<submission file="cnn_submission.py">' in output
     assert "(Line 1) import numpy as np" in output
 
 
 def test_pdf_example_openai_direct(capsys, mock_and_capture):
-    """
-    Example 3:
+    """Example 3:
     Evaluate pdf_example test using openAI model and direct output mode.
     python -m ai_feedback --prompt text_pdf_analyze --scope text \
         --submission test_submissions/pdf_example/student_pdf_submission.pdf \
@@ -86,3 +83,67 @@ def test_pdf_example_openai_direct(capsys, mock_and_capture):
     assert "Does the student correctly respond to the question, and meet all the" in output
     assert "student_pdf_submission.pdf" in output
     assert "Normalization allows each feature to have an equal influence on the mode" in output
+
+
+def test_xml_formatting_code_scope(capsys, mock_and_capture):
+    """
+    Test XML formatting for file contents in code scope.
+    Verifies that file contents use XML tags while file references remain plain text.
+    """
+    parent = Path(__file__).parent.parent.parent
+
+    args = [
+        "--prompt_text",
+        "File references: {file_references}\n\nFile contents:\n{file_contents}",
+        "--scope", 
+        "code",
+        "--submission",
+        str(parent / "test_submissions/csc108/correct_submission/correct_submission.py"),
+        "--solution",
+        str(parent / "test_submissions/csc108/solution.py"),
+        "--model",
+        "openai"
+    ]
+    output = run_cli_and_capture(args, capsys)
+    
+    assert "The student's submission file is correct_submission.py." in output
+    assert "The instructor's solution file is solution.py." in output
+    
+    assert '<submission file="correct_submission.py">' in output
+    assert '</submission>' in output
+    assert '<solution file="solution.py">' in output
+    assert '</solution>' in output
+
+    assert "(Line 1) def fizzbuzz(n: int) -> list:" in output
+
+
+def test_xml_formatting_text_scope_with_test_output(capsys, mock_and_capture):
+    """
+    Test XML formatting for file contents in text scope with all file types.
+    Verifies submission, solution, and test_output files all use XML formatting.
+    """
+    parent = Path(__file__).parent.parent.parent
+
+    args = [
+        "--prompt_text",
+        "File references: {file_references}\n\nFile contents:\n{file_contents}",
+        "--submission_type",
+        "python",
+        "--scope",
+        "text", 
+        "--submission",
+        str(parent / "test_submissions/ggr274_homework5/test1/student_submission.txt"),
+        "--solution",
+        str(parent / "test_submissions/ggr274_homework5/test1/Homework_5_solution.txt"),
+        "--model",
+        "openai"
+    ]
+    output = run_cli_and_capture(args, capsys)
+    
+    assert "The student's submission file is student_submission.txt." in output
+    assert "The instructor's solution file is Homework_5_solution.txt." in output  
+    
+    assert '<submission file="student_submission.txt">' in output
+    assert '</submission>' in output
+    assert '<solution file="Homework_5_solution.txt">' in output
+    assert '</solution>' in output

--- a/tests/open_ai_model_tests/integration_test.py
+++ b/tests/open_ai_model_tests/integration_test.py
@@ -29,8 +29,8 @@ def test_cnn_example_openai_stdout(capsys, mock_and_capture):
 
     assert "Compare the student's code and solution code. For each mistake" in output
     assert "(Line 1) import numpy as np" in output
-    assert '<submission file="cnn_submission.py">' in output
-    assert '<solution file="cnn_solution.py">' in output
+    assert '<submission filename="cnn_submission.py">' in output
+    assert '<solution filename="cnn_solution.py">' in output
 
 
 def test_cnn_example_custom_prompt_stdout(capsys, mock_and_capture):
@@ -56,7 +56,7 @@ def test_cnn_example_custom_prompt_stdout(capsys, mock_and_capture):
     ]
     output = run_cli_and_capture(args, capsys)
     assert "Evaluate the student's code readability." in output
-    assert '<submission file="cnn_submission.py">' in output
+    assert '<submission filename="cnn_submission.py">' in output
     assert "(Line 1) import numpy as np" in output
 
 
@@ -109,9 +109,9 @@ def test_xml_formatting_code_scope(capsys, mock_and_capture):
     assert "The student's submission file is correct_submission.py." in output
     assert "The instructor's solution file is solution.py." in output
 
-    assert '<submission file="correct_submission.py">' in output
+    assert '<submission filename="correct_submission.py">' in output
     assert '</submission>' in output
-    assert '<solution file="solution.py">' in output
+    assert '<solution filename="solution.py">' in output
     assert '</solution>' in output
 
     assert "(Line 1) def fizzbuzz(n: int) -> list:" in output
@@ -143,7 +143,7 @@ def test_xml_formatting_text_scope_with_test_output(capsys, mock_and_capture):
     assert "The student's submission file is student_submission.txt." in output
     assert "The instructor's solution file is Homework_5_solution.txt." in output
 
-    assert '<submission file="student_submission.txt">' in output
+    assert '<submission filename="student_submission.txt">' in output
     assert '</submission>' in output
-    assert '<solution file="Homework_5_solution.txt">' in output
+    assert '<solution filename="Homework_5_solution.txt">' in output
     assert '</solution>' in output


### PR DESCRIPTION
- `helpers/template_utils.py`: 
`=== {filename} === ` -> ` <submission file="correct_submission.py">`

Example:
```
Compare the student's code and solution code...

The student's submission file is correct_submission.py.
The instructor's solution file is solution.py.

Files to Reference:
<submission file="correct_submission.py">
(Line 1) def fizzbuzz(n: int) -> list:
...
</submission>

<solution file="solution.py">
(Line 1) def fizzbuzz(n: int) -> list:
...
</solution>
```

`test_output` is also included here.

- `integration_test.py`: Update tests.

I have also cleaned the commit history.